### PR TITLE
Pre-create additional terminal tabs

### DIFF
--- a/build-python-app/index.json
+++ b/build-python-app/index.json
@@ -30,6 +30,12 @@
   },
   "environment": {
     "hideintro": true,
+    "terminals": [
+      {
+        "name": "Terminal 2",
+        "target": "host01"
+      }
+    ],
     "uilayout": "editor-terminal"
   },
   "backend": {

--- a/build-python-app/step4.md
+++ b/build-python-app/step4.md
@@ -2,7 +2,7 @@ The command-line utility accepts a connection string to CockroachDB as an argume
 
 Run this command in the second terminal, replacing `<port>` with the port you noted in step 1:
 
-`python3 example.py 'postgresql://python:test@127.0.0.1:<port>/bank?sslmode=require'`
+`python3 example.py 'postgresql://python:test@127.0.0.1:<port>/bank?sslmode=require'`{{execute T2}}
 
 The output will show the account balances before and after the funds transfer:
 

--- a/json-support/index.json
+++ b/json-support/index.json
@@ -57,6 +57,16 @@
         "port": 8080
       }
     ],
+    "terminals": [
+      {
+        "name": "Terminal 2",
+        "target": "host01"
+      },
+      {
+        "name": "Terminal 3",
+        "target": "host01"
+      }
+    ],
     "uilayout": "editor-terminal"
   },
   "backend": {


### PR DESCRIPTION
In the Python and JSON tutorials, students run commands in
additional terminals. However, they don't seem to alway
auto-open as intended. So this PR pre-creates the terminals.