### PR TITLE
Multi-region Katacoda fixes

### DIFF
--- a/multi-region/foreground.sh
+++ b/multi-region/foreground.sh
@@ -3,4 +3,5 @@ cp -i cockroach-v21.1.0-beta.4.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
 cp -i cockroach-v21.1.0-beta.4.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
 cp -i cockroach-v21.1.0-beta.4.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+docker pull cockroachdb/movr:20.11.1
 exec cockroach demo --global --nodes 9 --empty --insecure

--- a/multi-region/step1.md
+++ b/multi-region/step1.md
@@ -1,10 +1,10 @@
 CockroachDB v21.1 offers improved multi-region capabilities that make it easier to run global applications. In this tutorial, you will experience these capabilities. Specifically, you will:
 
 1. Get access to a simulated, multi-region CockroachDB cluster.
-1. Run a workload on the cluster using our fictional vehicle-sharing application called MovR](https://www.cockroachlabs.com/docs/v21.1/movr.html).
+1. Run a workload on the cluster using our fictional vehicle-sharing application called [MovR](https://www.cockroachlabs.com/docs/v21.1/movr.html).
 1. See the effects of network latency on SQL query performance in the default (non-multi-region) configuration.
 1. Configure the cluster for good multi-region performance by issuing SQL statements that choose the right **survival goals** and **table localities**.
 
-To get you started, we're installing CockroachDB and then using the `cockroach demo` command to simulate a 9-node demo cluster spread across 3 regions, with network latency between regions simulated as well.
+To get you started, we're installing CockroachDB and MovR and then using the `cockroach demo` command to simulate a 9-node demo cluster spread across 3 regions, with network latency between regions simulated as well.
 
-Once you see the `root@127.0.0.1:26257/defaultdb>` prompt, click **Continue**.
+Once you see the `defaultdb>` prompt, click **Continue**.

--- a/multi-region/step3.md
+++ b/multi-region/step3.md
@@ -11,7 +11,7 @@ In terminal 2, load the MovR data set. The command options are mostly self-expla
 ```shell
 docker run -it --rm cockroachdb/movr:20.11.1 \
     --app-name "movr-load" \
-    --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" \
+    --url "postgres://root@[[HOST_IP]]:26257/movr?sslmode=disable" \
     --num-threads 1 \
     load \
     --num-users 100 \
@@ -33,7 +33,7 @@ Still in terminal 2, run MovR in the `us-east` region:
 ```shell
 docker run -it --rm cockroachdb/movr:20.11.1 \
     --app-name "movr-us-east" \
-    --url "postgres://root@docker.for.mac.localhost:26257/movr?sslmode=disable" \
+    --url "postgres://root@[[HOST_IP]]:26257/movr?sslmode=disable" \
     run \
     --city="boston" \
     --city="new york" \
@@ -45,7 +45,7 @@ In terminal 3, run MovR in the `us-west` region:
 ```shell
 docker run -it --rm cockroachdb/movr:20.11.1 \
     --app-name "movr-us-west" \
-    --url "postgres://root@docker.for.mac.localhost:26260/movr?sslmode=disable" \
+    --url "postgres://root@[[HOST_IP]]:26260/movr?sslmode=disable" \
     run \
     --city="los angeles" \
     --city="san francisco" \
@@ -57,7 +57,7 @@ In terminal 4, run MovR in the `eu-west` region:
 ```shell
 docker run -it --rm cockroachdb/movr:20.11.1 \
    --app-name "movr-eu-west" \
-   --url "postgres://root@docker.for.mac.localhost:26264/movr?sslmode=disable" \
+   --url "postgres://root@[[HOST_IP]]:26264/movr?sslmode=disable" \
    run \
    --city="amsterdam" \
    --city="paris" \


### PR DESCRIPTION
- Pull MovR image at start of the tutorial
- Auto-populate hostname for Movr connection string
- Fix a few formatting issues