### PR TITLE
Make multi-region tutorial private

### DIFF
--- a/multi-region/index.json
+++ b/multi-region/index.json
@@ -71,5 +71,6 @@
   },
   "backend": {
     "imageid": "ubuntu:1804"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
It's not working in a few ways:

- DB Console can't be reached because demo listens
  only on localhost, but Katacoda requires it to listen
  on all addresses.
- Can't figure out how to have the connection strings in
  the  Docker commands default to the right IP addresses.
  Bad UX when you try to have the user copy the command
  into the terminal and then edit it.