### PR TITLE
Fix spatial tutorial

### DIFF
--- a/build-python-app/foreground.sh
+++ b/build-python-app/foreground.sh
@@ -1,7 +1,7 @@
 pip install psycopg2-binary
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 exec cockroach demo --empty --embedded

--- a/json-support/foreground.sh
+++ b/json-support/foreground.sh
@@ -1,3 +1,3 @@
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 cockroach start-single-node --insecure

--- a/learn-cockroachdb-sql/foreground.sh
+++ b/learn-cockroachdb-sql/foreground.sh
@@ -1,6 +1,6 @@
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 exec cockroach demo --embedded

--- a/multi-region/foreground.sh
+++ b/multi-region/foreground.sh
@@ -1,7 +1,7 @@
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 docker pull cockroachdb/movr:20.11.1
 exec cockroach demo --global --nodes 9 --empty --embedded --insecure

--- a/playground-21.1/foreground.sh
+++ b/playground-21.1/foreground.sh
@@ -1,10 +1,10 @@
 echo 'Installing a testing release of CockroachDB v21.1 and supporting spatial libraries...'
 
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 
 echo 'Starting a secure single-node cluster...'
 

--- a/spatial-data/foreground.sh
+++ b/spatial-data/foreground.sh
@@ -1,6 +1,6 @@
-curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz
-cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+curl https://binaries.cockroachdb.com/cockroach-v21.1.9.linux-amd64.tgz | tar -xz
+cp -i cockroach-v21.1.9.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v21.1.7.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.9.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 exec cockroach demo --embedded

--- a/spatial-data/step3.md
+++ b/spatial-data/step3.md
@@ -8,7 +8,7 @@
 2. `IMPORT` the parts of the data set that live in the `tutorial` database.
 
     ```sql
-    IMPORT PGDUMP ('https://spatial-tutorial.s3.us-east-2.amazonaws.com/bookstores-and-roads-20210125.sql');
+    IMPORT PGDUMP ('https://spatial-tutorial.s3.us-east-2.amazonaws.com/bookstores-and-roads-20210125.sql') WITH ignore_unsupported_statements;
     ```{{execute}}
 
 3. Create a `birds` database, and use it.
@@ -21,7 +21,7 @@
 4. `IMPORT` the parts of the data set that live in the `birds` database.
 
     ```sql
-    IMPORT PGDUMP ('https://spatial-tutorial.s3.us-east-2.amazonaws.com/birds-20210125.sql');
+    IMPORT PGDUMP ('https://spatial-tutorial.s3.us-east-2.amazonaws.com/birds-20210125.sql') WITH ignore_unsupported_statements;
     ```{{execute}}
 
 5. Switch back to the `tutorial` database. All of the queries in this tutorial assume you are in the `tutorial` database.


### PR DESCRIPTION
- Add `WITH ignore_unsupported_statements` to `IMPORT PGDUMP` statements in spatial tutorial. This was a backward-incompatible change in a v21.1 patch release. 
- Also upgrade all v21.1. tutorials to 21.1.9.